### PR TITLE
feat: add login endpoint for EntreLibros backend

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,18 @@
+name: Maven CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -B verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,5 +14,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
+      - name: Verify Docker
+        run: docker ps
       - name: Build with Maven
         run: mvn -B verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Maven
+/target/
+
+# IDEs
+/.idea/
+*.iml
+
+# Logs
+*.log
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
 
 - Java 21
 - Maven 3.9+
-- Docker (para ejecutar PostgreSQL y los tests)
+- Docker (opcional, para ejecutar PostgreSQL)
 
 ## Ejecutar en local
 
@@ -43,22 +43,6 @@ Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
 - Ejecutar pruebas: `mvn test`
 - Compilar sin pruebas: `mvn -DskipTests package`
 - Ver dependencias: `mvn dependency:tree`
-
-## Problemas comunes
-
-### Docker no disponible en tests
-
-Los tests usan Testcontainers para levantar PostgreSQL en un contenedor. Si al ejecutar `mvn test` aparece `IllegalState: Could not find a valid Docker environment`:
-
-1. Asegúrate de que Docker esté instalado y en ejecución:
-   ```bash
-   docker ps
-   ```
-2. En Linux, agrega tu usuario al grupo `docker` y reinicia sesión:
-   ```bash
-   sudo usermod -aG docker $USER
-   ```
-3. Si Docker no está disponible, salta las pruebas con `mvn -DskipTests test` o anota los tests con `@Testcontainers(disabledWithoutDocker = true)`.
 
 ## Documentación
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
 
 - Java 21
 - Maven 3.9+
-- Docker (opcional, para ejecutar PostgreSQL)
+- Docker (requerido para pruebas y bases de datos mediante Testcontainers)
 
 ## Ejecutar en local
 
@@ -24,7 +24,7 @@ Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
    JWT_ACCESS_TTL=PT15M
    JWT_REFRESH_TTL=P14D
    ```
-3. Levanta PostgreSQL (opcional mediante Docker):
+3. Levanta PostgreSQL (por ejemplo con Docker):
    ```bash
    docker run --name entrelibros-db -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=entrelibros -p 5432:5432 -d postgres:16-alpine
    ```
@@ -40,7 +40,7 @@ Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
 
 ## Comandos útiles
 
-- Ejecutar pruebas: `mvn test`
+- Ejecutar pruebas (requiere Docker): `mvn test`
 - Compilar sin pruebas: `mvn -DskipTests package`
 - Ver dependencias: `mvn dependency:tree`
 

--- a/README.md
+++ b/README.md
@@ -1,395 +1,65 @@
-# 📚 EntreLibros Backend (Spring Boot 3.x, Java 21)
-
-**API segura, moderna y con buenas prácticas** para la plataforma EntreLibros. Implementada con **Spring Boot 3.x (Java 21, virtual threads opcional)**, **Spring Security 6 (JWT + Refresh en cookie httpOnly)**, **PostgreSQL 16 + Flyway + Spring Data JPA**, contratos **OpenAPI 3** y **Testcontainers** para pruebas integradas. Logs estructurados, métricas con **Micrometer/Prometheus** y trazas **OpenTelemetry**.
-
-> **Nota de estilo**: el README está en español; **todo el código y los comentarios del código van en inglés** (preferencia del proyecto).
-
----
-
-## 🧱 Stack
-
-* **Runtime**: Java 21 (virtual threads habilitable con `spring.threads.virtual.enabled=true`)
-* **Framework**: Spring Boot 3.x (Web, Validation)
-* **Seguridad**: Spring Security 6 (OAuth2 Resource Server), JWT access + **refresh en cookie httpOnly/SameSite=strict**
-* **Persistencia**: PostgreSQL 16, Spring Data JPA (Hibernate), **Flyway** para migraciones
-* **Contratos**: springdoc-openapi (Swagger UI `/docs`), OpenAPI generado en build
-* **Mapper**: MapStruct
-* **Caching / Rate-limit**: Caffeine (local), Bucket4j (filtro) para protección básica
-* **Observabilidad**: Micrometer + Prometheus, OpenTelemetry OTLP, logs JSON (Logback) con `traceId`/`spanId`
-* **Testing**: JUnit 5, Testcontainers (Postgres), WebTestClient/MockMvc, AssertJ, Mockito
-* **Build**: Gradle (Kotlin DSL), Dockerfile multi-stage + Jib opcional
-
----
-
-## 🎯 Principios
-
-* **Contrato primero**: cualquier cambio en endpoints debe actualizar OpenAPI y pruebas de contrato.
-* **Seguridad por defecto**: mínimos privilegios, headers seguros, saneamiento y validación.
-* **Compatibilidad FE**: claves de i18n en errores (p.ej. `auth.errors.invalid_credentials`).
-* **Trazabilidad**: `X-Request-Id` → MDC → logs JSON + métricas por endpoint.
-
----
-
-## 🔐 Autenticación y sesión
-
-* **Login** devuelve `accessToken` (JWT corto, p.ej. 15 min) en el body **y** setea cookie `sessionToken` (refresh) **httpOnly, Secure, SameSite=Strict**, con rotación automática en `/auth/refresh` (interno).
-* **Logout** invalida el refresh server-side (lista de deny / token version) y expira la cookie.
-* **Protección**: CSRF no aplica a endpoints `stateless` con JWT; para formularios con cookie se añade **CSRF** si se habilita modo `session`.
-* **Hash** de contraseñas: **Argon2id** (`PasswordEncoder` de Spring Security).
-
----
-
-## 📡 API — Endpoints del MVP
-
-**Base URL:** `/api/v1`
-
-> Respuestas exitosas envuelven `{ "data": ..., "meta": { ... } }` cuando aplica. Errores siguen **RFC 9457 Problem Details** con extensiones `{ code, messageKey, details }` para i18n del FE.
-
-### 1) Autenticación
-
-#### `POST /auth/login`
-
-Inicia sesión de un usuario válido.
-
-**Request**
-
-```json
-{
-  "email": "user@entrelibros.com",
-  "password": "correcthorsebatterystaple"
-}
-```
-
-**200**
-
-```json
-{
-  "data": {
-    "token": "eyJhbGciOiJIUzI1NiIs...",
-    "user": { "id": "1", "email": "user@entrelibros.com", "role": "user" },
-    "messageKey": "auth.success.login"
-  }
-}
-```
-
-Cabecera: `Set-Cookie: sessionToken=...; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth`
-
-**401**
-
-```json
-{
-  "type": "about:blank",
-  "title": "Unauthorized",
-  "status": 401,
-  "code": "InvalidCredentials",
-  "messageKey": "auth.errors.invalid_credentials"
-}
-```
-
-#### `POST /auth/logout`
-
-Requiere cookie `sessionToken` válida. Invalida refresh y expira cookie.
-
-**200**
-
-```json
-{ "data": { "message": "Successfully logged out", "timestamp": "2024-02-20T15:00:00Z" } }
-```
-
-#### `GET /auth/me`
-
-Devuelve el usuario autenticado (JWT `Authorization: Bearer <access>` **o** cookie `sessionToken` + refresh-flow server-side).
-
-**200**
-
-```json
-{ "data": { "id": "u_1", "email": "demo@entrelibros.app", "roles": ["user"] } }
-```
-
-**401** → Problem Details como arriba.
-
-#### `POST /auth/register`
-
-**Request**
-
-```json
-{ "name": "Jane Doe", "email": "new@entrelibros.com", "password": "secreta" }
-```
-
-**201**
-
-```json
-{
-  "data": {
-    "token": "fake-register-token",
-    "user": { "id": "2", "email": "new@entrelibros.com", "role": "user" },
-    "messageKey": "auth.success.register"
-  }
-}
-```
-
-**409**
-
-```json
-{
-  "type": "about:blank",
-  "title": "Conflict",
-  "status": 409,
-  "code": "EmailExists",
-  "messageKey": "auth.errors.email_exists"
-}
-```
-
----
-
-### 2) Formularios y contacto
-
-#### `POST /contact/submit`
-
-**Request**
-
-```json
-{ "name": "María Pérez", "email": "maria@example.com", "message": "Quisiera más información sobre la plataforma." }
-```
-
-**200**
-
-```json
-{ "data": { "message": "¡Gracias por tu mensaje! Te responderemos lo antes posible." } }
-```
-
-**400/500** → Problem Details con `messageKey` descriptivo.
-
-> **Implementación**: encolar evento `CONTACT_SUBMITTED` y enviar email (Mailpit en dev / SMTP/Resend en prod). Rate-limit por IP.
-
----
-
-### 3) Libros
-
-#### `GET /books`
-
-Lista pública (paginada) de libros.
-
-**200**
-
-```json
-{
-  "data": [
-    { "title": "1984", "author": "George Orwell", "coverUrl": "https://covers.openlibrary.org/b/id/7222246-L.jpg" }
-  ],
-  "meta": { "page": 0, "size": 20, "total": 1 }
-}
-```
-
-#### `GET /books/mine` (auth)
-
-Libros publicados por el usuario autenticado.
-
-**200**
-
-```json
-{
-  "data": [
-    {
-      "id": "1",
-      "title": "Matisse en Bélgica",
-      "author": "Carlos Argan",
-      "coverUrl": "https://covers.openlibrary.org/b/id/9875161-L.jpg",
-      "condition": "bueno",
-      "status": "available",
-      "isForSale": true,
-      "price": 15000
-    }
-  ]
-}
-```
-
----
-
-### 4) Comunidad
-
-#### `GET /community/stats`
-
-**200**
-
-```json
-{
-  "data": {
-    "kpis": { "exchanges": 134, "activeHouses": 52, "activeUsers": 318, "booksPublished": 2140 },
-    "trendExchanges": [65,80,55,90,70,40,85],
-    "trendNewBooks": [30,45,35,60,50,40,55]
-  }
-}
-```
-
-#### `GET /community/feed`
-
-Query params: `page` (default 0), `size` (default 8)
-
-**200**
-
-```json
-{
-  "data": [
-    {
-      "id": "uuid",
-      "user": "Ana",
-      "avatar": "https://example.com/avatar.png",
-      "time": "hace 2h",
-      "likes": 5,
-      "type": "book",
-      "title": "Dune",
-      "author": "Frank Herbert",
-      "cover": "https://picsum.photos/seed/1/600/400"
-    }
-  ],
-  "meta": { "page": 0, "size": 8, "total": 1 }
-}
-```
-
-#### `GET /community/activity`
-
-**200**
-
-```json
-{ "data": [ { "id": "uuid", "user": "Lucía", "avatar": "https://example.com/avatar.png" } ] }
-```
-
-#### `GET /community/suggestions`
-
-**200**
-
-```json
-{ "data": [ { "id": "uuid", "user": "Pedro", "avatar": "https://example.com/avatar.png" } ] }
-```
-
----
-
-## 🧩 Modelos básicos (concepto)
-
-* **User**: id, email (único), name, roles\[], passwordHash, language, createdAt
-* **Book**: id, title, author(s), coverUrl, tags\[]
-* **BookOwnership**: id, userId, bookId, condition, status, isForSale, price
-* **FeedItem**: id, type(`book|swap|sale|seeking`), payload(JSONB), createdAt
-* **ContactMessage**: id, name, email, message, createdAt
-
----
-
-## 🔧 Configuración
-
-Variables de entorno (validadas con `@ConfigurationProperties` + `jakarta.validation`):
-
-```properties
-SERVER_PORT=4000
-API_PREFIX=/api
-API_VERSION=v1
-CORS_ORIGINS=http://localhost:3000
-
-DB_URL=jdbc:postgresql://postgres:5432/entrelibros
-DB_USER=postgres
-DB_PASS=postgres
-
-JWT_ISSUER=https://entrelibros.app
-JWT_ACCESS_TTL=PT15M
-JWT_REFRESH_TTL=P14D
-JWT_ACCESS_PUBLIC_KEY=... # RS256 recomendado
-JWT_ACCESS_PRIVATE_KEY=...
-
-RATE_LIMIT_WINDOW=60s
-RATE_LIMIT_MAX=120
-```
-
----
-
-## 🐳 Docker / Dev
-
-* **PostgreSQL** + **Mailpit** en `docker-compose.dev.yml`.
-* Ejecutar app: `./gradlew bootRun` (o `java -jar` del jar empaquetado).
-* **Testcontainers** arranca Postgres aislado en tests: `./gradlew test`.
-
-```yaml
-services:
-  postgres:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: entrelibros
-    ports: ["5432:5432"]
-    volumes: ["db_data:/var/lib/postgresql/data"]
-  mailpit:
-    image: axllent/mailpit
-    ports: ["8025:8025", "1025:1025"]
-volumes:
-  db_data:
-```
-
----
-
-## 🔒 Buenas prácticas aplicadas
-
-* **JWT RS256** con rotación de refresh, cookie httpOnly/Secure/SameSite=Strict, `Path` limitado.
-* **Argon2id** para contraseñas; política de bloqueo por intentos fallidos.
-* **CORS** explícito por entorno; **Helmet-equivalente** en Spring Security (CSP, HSTS, X-Frame-Options, etc.).
-* **Validación** con Bean Validation + sanitización; límites de tamaño (`spring.servlet.multipart` y `maxPayloadSize`).
-* **Rate-limit** Bucket4j por IP/route; **circuit breakers** opcionales con Resilience4j.
-* **Observabilidad** out-of-the-box: `/actuator/health`, `/actuator/metrics`, trazas OTel.
-* **Migrations** con Flyway y `baselineOnMigrate=true` en entornos existentes.
-* **Zero-downtime**: `readiness/liveness` probes; **layered jar** para imágenes pequeñas.
-
----
-
-## 🧪 Pruebas
-
-* **Unitarias**: servicios, mappers, validaciones
-* **Integración**: repos + seguridad con Testcontainers
-* **E2E (contrato)**: WebTestClient contra contexto real y verificación OpenAPI
-* **Escenarios críticos**: login/logout, `/books/mine`, feed paginado, envío de contacto
-
----
-
-## 📄 Documentación OpenAPI
-
-* Swagger UI: `GET /docs`
-* OpenAPI JSON: `GET /docs/openapi.json` (se commitea en `docs/openapi.json`)
-
----
-
-## 🧷 Ejemplos de seguridad (headers)
-
-* `Strict-Transport-Security: max-age=31536000; includeSubDomains` (prod)
-* `Content-Security-Policy: default-src 'self'; img-src 'self' data: https://covers.openlibrary.org`
-* `X-Content-Type-Options: nosniff`
-* `X-Frame-Options: DENY`
-
----
-
-## ✅ Checklists de entrega
-
-* [ ] OpenAPI actualizado y publicado en `/docs`
-* [ ] Flyway migrations aplicadas en CI + entorno
-* [ ] `CORS_ORIGINS` correcto y pruebas de navegador OK
-* [ ] Rate-limit y logs JSON verificados (con `X-Request-Id`)
-* [ ] Tests verdes (unit/integration/e2e) con Testcontainers
-
----
-
-## 🤝 Contribución
-
-1. Branch `feat/<feature>`
-2. Añadí tests y actualizá OpenAPI si toca endpoints
-3. `./gradlew check` y calidad estática
-4. PR con descripción de contrato, riesgos y migración
-
----
-
-## 🔎 Notas de diseño
-
-* **Errores** usan Problem Details; el FE puede leer `code`/`messageKey` para i18n.
-* **Paginación**: endpoints públicos con `page/size` (compatibilidad actual del FE). En V1 considerar **cursor** donde corresponda.
-* **Contact**: asincronía por evento + email; dev: Mailpit, prod: SMTP/Resend.
-
----
-
-## 🧠 Decisiones (y qué descartamos)
-
-**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, Testcontainers, Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.
+# 📚 EntreLibros Backend
+
+Backend de la plataforma EntreLibros construido con Spring Boot 3 y Java 21.
+
+## Requisitos
+
+- Java 21
+- Maven 3.9+
+- Docker (para ejecutar PostgreSQL y los tests)
+
+## Ejecutar en local
+
+1. Clona el repositorio:
+   ```bash
+   git clone <repo-url> && cd EntreLibros_Backend
+   ```
+2. Configura las variables de entorno necesarias (ejemplo):
+   ```properties
+   SERVER_PORT=4000
+   DB_URL=jdbc:postgresql://localhost:5432/entrelibros
+   DB_USER=postgres
+   DB_PASS=postgres
+   JWT_ISSUER=https://entrelibros.app
+   JWT_ACCESS_TTL=PT15M
+   JWT_REFRESH_TTL=P14D
+   ```
+3. Levanta PostgreSQL (opcional mediante Docker):
+   ```bash
+   docker run --name entrelibros-db -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=entrelibros -p 5432:5432 -d postgres:16-alpine
+   ```
+4. Ejecuta la aplicación:
+   ```bash
+   mvn spring-boot:run
+   ```
+   o bien empaqueta y ejecuta el jar:
+   ```bash
+   mvn clean package
+   java -jar target/entrelibros-backend-0.0.1-SNAPSHOT.jar
+   ```
+
+## Comandos útiles
+
+- Ejecutar pruebas: `mvn test`
+- Compilar sin pruebas: `mvn -DskipTests package`
+- Ver dependencias: `mvn dependency:tree`
+
+## Problemas comunes
+
+### Docker no disponible en tests
+
+Los tests usan Testcontainers para levantar PostgreSQL en un contenedor. Si al ejecutar `mvn test` aparece `IllegalState: Could not find a valid Docker environment`:
+
+1. Asegúrate de que Docker esté instalado y en ejecución:
+   ```bash
+   docker ps
+   ```
+2. En Linux, agrega tu usuario al grupo `docker` y reinicia sesión:
+   ```bash
+   sudo usermod -aG docker $USER
+   ```
+3. Si Docker no está disponible, salta las pruebas con `mvn -DskipTests test` o anota los tests con `@Testcontainers(disabledWithoutDocker = true)`.
+
+## Documentación
+
+La documentación completa y los endpoints están en la carpeta [docs](docs/).

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,225 @@
+## 📡 API — Endpoints del MVP
+
+**Base URL:** `/api/v1`
+
+> Respuestas exitosas envuelven `{ "data": ..., "meta": { ... } }` cuando aplica. Errores siguen **RFC 9457 Problem Details** con extensiones `{ code, messageKey, details }` para i18n del FE.
+
+### 1) Autenticación
+
+#### `POST /auth/login`
+
+Inicia sesión de un usuario válido.
+
+**Request**
+
+```json
+{
+  "email": "user@entrelibros.com",
+  "password": "correcthorsebatterystaple"
+}
+```
+
+**200**
+
+```json
+{
+  "data": {
+    "token": "eyJhbGciOiJIUzI1NiIs...",
+    "user": { "id": "1", "email": "user@entrelibros.com", "role": "user" },
+    "messageKey": "auth.success.login"
+  }
+}
+```
+
+Cabecera: `Set-Cookie: sessionToken=...; HttpOnly; Secure; SameSite=Strict; Path=/api/v1/auth`
+
+**401**
+
+```json
+{
+  "type": "about:blank",
+  "title": "Unauthorized",
+  "status": 401,
+  "code": "InvalidCredentials",
+  "messageKey": "auth.errors.invalid_credentials"
+}
+```
+
+#### `POST /auth/logout`
+
+Requiere cookie `sessionToken` válida. Invalida refresh y expira cookie.
+
+**200**
+
+```json
+{ "data": { "message": "Successfully logged out", "timestamp": "2024-02-20T15:00:00Z" } }
+```
+
+#### `GET /auth/me`
+
+Devuelve el usuario autenticado (JWT `Authorization: Bearer <access>` **o** cookie `sessionToken` + refresh-flow server-side).
+
+**200**
+
+```json
+{ "data": { "id": "u_1", "email": "demo@entrelibros.app", "roles": ["user"] } }
+```
+
+**401** → Problem Details como arriba.
+
+#### `POST /auth/register`
+
+**Request**
+
+```json
+{ "name": "Jane Doe", "email": "new@entrelibros.com", "password": "secreta" }
+```
+
+**201**
+
+```json
+{
+  "data": {
+    "token": "fake-register-token",
+    "user": { "id": "2", "email": "new@entrelibros.com", "role": "user" },
+    "messageKey": "auth.success.register"
+  }
+}
+```
+
+**409**
+
+```json
+{
+  "type": "about:blank",
+  "title": "Conflict",
+  "status": 409,
+  "code": "EmailExists",
+  "messageKey": "auth.errors.email_exists"
+}
+```
+
+---
+
+### 2) Formularios y contacto
+
+#### `POST /contact/submit`
+
+**Request**
+
+```json
+{ "name": "María Pérez", "email": "maria@example.com", "message": "Quisiera más información sobre la plataforma." }
+```
+
+**200**
+
+```json
+{ "data": { "message": "¡Gracias por tu mensaje! Te responderemos lo antes posible." } }
+```
+
+**400/500** → Problem Details con `messageKey` descriptivo.
+
+> **Implementación**: encolar evento `CONTACT_SUBMITTED` y enviar email (Mailpit en dev / SMTP/Resend en prod). Rate-limit por IP.
+
+---
+
+### 3) Libros
+
+#### `GET /books`
+
+Lista pública (paginada) de libros.
+
+**200**
+
+```json
+{
+  "data": [
+    { "title": "1984", "author": "George Orwell", "coverUrl": "https://covers.openlibrary.org/b/id/7222246-L.jpg" }
+  ],
+  "meta": { "page": 0, "size": 20, "total": 1 }
+}
+```
+
+#### `GET /books/mine` (auth)
+
+Libros publicados por el usuario autenticado.
+
+**200**
+
+```json
+{
+  "data": [
+    {
+      "id": "1",
+      "title": "Matisse en Bélgica",
+      "author": "Carlos Argan",
+      "coverUrl": "https://covers.openlibrary.org/b/id/9875161-L.jpg",
+      "condition": "bueno",
+      "status": "available",
+      "isForSale": true,
+      "price": 15000
+    }
+  ]
+}
+```
+
+---
+
+### 4) Comunidad
+
+#### `GET /community/stats`
+
+**200**
+
+```json
+{
+  "data": {
+    "kpis": { "exchanges": 134, "activeHouses": 52, "activeUsers": 318, "booksPublished": 2140 },
+    "trendExchanges": [65,80,55,90,70,40,85],
+    "trendNewBooks": [30,45,35,60,50,40,55]
+  }
+}
+```
+
+#### `GET /community/feed`
+
+Query params: `page` (default 0), `size` (default 8)
+
+**200**
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "user": "Ana",
+      "avatar": "https://example.com/avatar.png",
+      "time": "hace 2h",
+      "likes": 5,
+      "type": "book",
+      "title": "Dune",
+      "author": "Frank Herbert",
+      "cover": "https://picsum.photos/seed/1/600/400"
+    }
+  ],
+  "meta": { "page": 0, "size": 8, "total": 1 }
+}
+```
+
+#### `GET /community/activity`
+
+**200**
+
+```json
+{ "data": [ { "id": "uuid", "user": "Lucía", "avatar": "https://example.com/avatar.png" } ] }
+```
+
+#### `GET /community/suggestions`
+
+**200**
+
+```json
+{ "data": [ { "id": "uuid", "user": "Pedro", "avatar": "https://example.com/avatar.png" } ] }
+```
+
+---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@
 * **Mapper**: MapStruct
 * **Caching / Rate-limit**: Caffeine (local), Bucket4j (filtro) para protección básica
 * **Observabilidad**: Micrometer + Prometheus, OpenTelemetry OTLP, logs JSON (Logback) con `traceId`/`spanId`
-* **Testing**: JUnit 5, H2 en memoria, MockMvc, AssertJ, Mockito
+* **Testing**: JUnit 5, PostgreSQL (Testcontainers), MockMvc, AssertJ, Mockito
 * **Build**: Gradle (Kotlin DSL), Dockerfile multi-stage + Jib opcional
 
 ---
@@ -108,7 +108,7 @@ volumes:
 ## 🧪 Pruebas
 
 * **Unitarias**: servicios, mappers, validaciones
-* **Integración**: repos + seguridad con H2 en memoria
+* **Integración**: repos + seguridad con PostgreSQL (Testcontainers)
 * **E2E (contrato)**: WebTestClient contra contexto real y verificación OpenAPI
 * **Escenarios críticos**: login/logout, `/books/mine`, feed paginado, envío de contacto
 
@@ -136,7 +136,7 @@ volumes:
 * [ ] Flyway migrations aplicadas en CI + entorno
 * [ ] `CORS_ORIGINS` correcto y pruebas de navegador OK
 * [ ] Rate-limit y logs JSON verificados (con `X-Request-Id`)
-* [ ] Tests verdes (unit/integration/e2e) con H2 en memoria
+* [ ] Tests verdes (unit/integration/e2e) con PostgreSQL (Testcontainers)
 
 ---
 
@@ -159,4 +159,4 @@ volumes:
 
 ## 🧠 Decisiones (y qué descartamos)
 
-**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, H2 para tests, Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.
+**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, PostgreSQL para tests (Testcontainers), Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,163 @@
+# Documentación adicional
+
+## 🧱 Stack
+
+* **Runtime**: Java 21 (virtual threads habilitable con `spring.threads.virtual.enabled=true`)
+* **Framework**: Spring Boot 3.x (Web, Validation)
+* **Seguridad**: Spring Security 6 (OAuth2 Resource Server), JWT access + **refresh en cookie httpOnly/SameSite=strict**
+* **Persistencia**: PostgreSQL 16, Spring Data JPA (Hibernate), **Flyway** para migraciones
+* **Contratos**: springdoc-openapi (Swagger UI `/docs`), OpenAPI generado en build
+* **Mapper**: MapStruct
+* **Caching / Rate-limit**: Caffeine (local), Bucket4j (filtro) para protección básica
+* **Observabilidad**: Micrometer + Prometheus, OpenTelemetry OTLP, logs JSON (Logback) con `traceId`/`spanId`
+* **Testing**: JUnit 5, Testcontainers (Postgres), WebTestClient/MockMvc, AssertJ, Mockito
+* **Build**: Gradle (Kotlin DSL), Dockerfile multi-stage + Jib opcional
+
+---
+
+## 🎯 Principios
+
+* **Contrato primero**: cualquier cambio en endpoints debe actualizar OpenAPI y pruebas de contrato.
+* **Seguridad por defecto**: mínimos privilegios, headers seguros, saneamiento y validación.
+* **Compatibilidad FE**: claves de i18n en errores (p.ej. `auth.errors.invalid_credentials`).
+* **Trazabilidad**: `X-Request-Id` → MDC → logs JSON + métricas por endpoint.
+
+---
+
+## 🔐 Autenticación y sesión
+
+* **Login** devuelve `accessToken` (JWT corto, p.ej. 15 min) en el body **y** setea cookie `sessionToken` (refresh) **httpOnly, Secure, SameSite=Strict**, con rotación automática en `/auth/refresh` (interno).
+* **Logout** invalida el refresh server-side (lista de deny / token version) y expira la cookie.
+* **Protección**: CSRF no aplica a endpoints `stateless` con JWT; para formularios con cookie se añade **CSRF** si se habilita modo `session`.
+* **Hash** de contraseñas: **Argon2id** (`PasswordEncoder` de Spring Security).
+
+---
+
+## 🧩 Modelos básicos (concepto)
+
+* **User**: id, email (único), name, roles\[], passwordHash, language, createdAt
+* **Book**: id, title, author(s), coverUrl, tags\[]
+* **BookOwnership**: id, userId, bookId, condition, status, isForSale, price
+* **FeedItem**: id, type(`book|swap|sale|seeking`), payload(JSONB), createdAt
+* **ContactMessage**: id, name, email, message, createdAt
+
+---
+
+## 🔧 Configuración
+
+Variables de entorno (validadas con `@ConfigurationProperties` + `jakarta.validation`):
+
+```properties
+SERVER_PORT=4000
+API_PREFIX=/api
+API_VERSION=v1
+CORS_ORIGINS=http://localhost:3000
+
+DB_URL=jdbc:postgresql://postgres:5432/entrelibros
+DB_USER=postgres
+DB_PASS=postgres
+
+JWT_ISSUER=https://entrelibros.app
+JWT_ACCESS_TTL=PT15M
+JWT_REFRESH_TTL=P14D
+JWT_ACCESS_PUBLIC_KEY=... # RS256 recomendado
+JWT_ACCESS_PRIVATE_KEY=...
+
+RATE_LIMIT_WINDOW=60s
+RATE_LIMIT_MAX=120
+```
+
+---
+
+## 🐳 Docker / Dev
+
+* **PostgreSQL** + **Mailpit** en `docker-compose.dev.yml`.
+* Ejecutar app: `./gradlew bootRun` (o `java -jar` del jar empaquetado).
+* **Testcontainers** arranca Postgres aislado en tests: `./gradlew test`.
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: entrelibros
+    ports: ["5432:5432"]
+    volumes: ["db_data:/var/lib/postgresql/data"]
+  mailpit:
+    image: axllent/mailpit
+    ports: ["8025:8025", "1025:1025"]
+volumes:
+  db_data:
+```
+
+---
+
+## 🔒 Buenas prácticas aplicadas
+
+* **JWT RS256** con rotación de refresh, cookie httpOnly/Secure/SameSite=Strict, `Path` limitado.
+* **Argon2id** para contraseñas; política de bloqueo por intentos fallidos.
+* **CORS** explícito por entorno; **Helmet-equivalente** en Spring Security (CSP, HSTS, X-Frame-Options, etc.).
+* **Validación** con Bean Validation + sanitización; límites de tamaño (`spring.servlet.multipart` y `maxPayloadSize`).
+* **Rate-limit** Bucket4j por IP/route; **circuit breakers** opcionales con Resilience4j.
+* **Observabilidad** out-of-the-box: `/actuator/health`, `/actuator/metrics`, trazas OTel.
+* **Migrations** con Flyway y `baselineOnMigrate=true` en entornos existentes.
+* **Zero-downtime**: `readiness/liveness` probes; **layered jar** para imágenes pequeñas.
+
+---
+
+## 🧪 Pruebas
+
+* **Unitarias**: servicios, mappers, validaciones
+* **Integración**: repos + seguridad con Testcontainers
+* **E2E (contrato)**: WebTestClient contra contexto real y verificación OpenAPI
+* **Escenarios críticos**: login/logout, `/books/mine`, feed paginado, envío de contacto
+
+---
+
+## 📄 Documentación OpenAPI
+
+* Swagger UI: `GET /docs`
+* OpenAPI JSON: `GET /docs/openapi.json` (se commitea en `docs/openapi.json`)
+
+---
+
+## 🧷 Ejemplos de seguridad (headers)
+
+* `Strict-Transport-Security: max-age=31536000; includeSubDomains` (prod)
+* `Content-Security-Policy: default-src 'self'; img-src 'self' data: https://covers.openlibrary.org`
+* `X-Content-Type-Options: nosniff`
+* `X-Frame-Options: DENY`
+
+---
+
+## ✅ Checklists de entrega
+
+* [ ] OpenAPI actualizado y publicado en `/docs`
+* [ ] Flyway migrations aplicadas en CI + entorno
+* [ ] `CORS_ORIGINS` correcto y pruebas de navegador OK
+* [ ] Rate-limit y logs JSON verificados (con `X-Request-Id`)
+* [ ] Tests verdes (unit/integration/e2e) con Testcontainers
+
+---
+
+## 🤝 Contribución
+
+1. Branch `feat/<feature>`
+2. Añadí tests y actualizá OpenAPI si toca endpoints
+3. `./gradlew check` y calidad estática
+4. PR con descripción de contrato, riesgos y migración
+
+---
+
+## 🔎 Notas de diseño
+
+* **Errores** usan Problem Details; el FE puede leer `code`/`messageKey` para i18n.
+* **Paginación**: endpoints públicos con `page/size` (compatibilidad actual del FE). En V1 considerar **cursor** donde corresponda.
+* **Contact**: asincronía por evento + email; dev: Mailpit, prod: SMTP/Resend.
+
+---
+
+## 🧠 Decisiones (y qué descartamos)
+
+**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, Testcontainers, Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@
 * **Mapper**: MapStruct
 * **Caching / Rate-limit**: Caffeine (local), Bucket4j (filtro) para protección básica
 * **Observabilidad**: Micrometer + Prometheus, OpenTelemetry OTLP, logs JSON (Logback) con `traceId`/`spanId`
-* **Testing**: JUnit 5, Testcontainers (Postgres), WebTestClient/MockMvc, AssertJ, Mockito
+* **Testing**: JUnit 5, H2 en memoria, MockMvc, AssertJ, Mockito
 * **Build**: Gradle (Kotlin DSL), Dockerfile multi-stage + Jib opcional
 
 ---
@@ -73,7 +73,6 @@ RATE_LIMIT_MAX=120
 
 * **PostgreSQL** + **Mailpit** en `docker-compose.dev.yml`.
 * Ejecutar app: `./gradlew bootRun` (o `java -jar` del jar empaquetado).
-* **Testcontainers** arranca Postgres aislado en tests: `./gradlew test`.
 
 ```yaml
 services:
@@ -109,7 +108,7 @@ volumes:
 ## 🧪 Pruebas
 
 * **Unitarias**: servicios, mappers, validaciones
-* **Integración**: repos + seguridad con Testcontainers
+* **Integración**: repos + seguridad con H2 en memoria
 * **E2E (contrato)**: WebTestClient contra contexto real y verificación OpenAPI
 * **Escenarios críticos**: login/logout, `/books/mine`, feed paginado, envío de contacto
 
@@ -137,7 +136,7 @@ volumes:
 * [ ] Flyway migrations aplicadas en CI + entorno
 * [ ] `CORS_ORIGINS` correcto y pruebas de navegador OK
 * [ ] Rate-limit y logs JSON verificados (con `X-Request-Id`)
-* [ ] Tests verdes (unit/integration/e2e) con Testcontainers
+* [ ] Tests verdes (unit/integration/e2e) con H2 en memoria
 
 ---
 
@@ -160,4 +159,4 @@ volumes:
 
 ## 🧠 Decisiones (y qué descartamos)
 
-**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, Testcontainers, Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.
+**Elegimos**: Spring Boot 3.x (Java 21), Security 6 con JWT + refresh cookie, Postgres + JPA/Flyway, OpenAPI springdoc, H2 para tests, Argon2id, Bucket4j y observabilidad OTel/Micrometer. **Descartamos**: NestJS/Node para este repo (duplicaba tipos y no cumple tu pedido de Spring), sesiones de servidor puras (preferimos JWT stateless + refresh cookie), y jOOQ por ahora (JPA suficiente en el MVP; jOOQ se evalúa para consultas complejas). **Criterio**: máxima seguridad/patrón actual de la industria, compatibilidad con tu FE y time-to-value rápido sin deuda innecesaria.

--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,104 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.entrelibros</groupId>
+  <artifactId>entrelibros-backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>EntreLibros Backend</name>
+  <description>Backend for EntreLibros platform</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring.boot.version>3.2.5</spring.boot.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Spring Boot starters -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
+    <!-- Database -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+
+    <!-- JWT -->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.11.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,19 @@
       <version>0.11.5</version>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt-jackson</artifactId>
-      <version>0.11.5</version>
-      <scope>runtime</scope>
-    </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId>
+        <version>0.11.5</version>
+        <scope>runtime</scope>
+      </dependency>
+
+      <!-- Password hashing -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>1.78.1</version>
+      </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/src/main/java/com/entrelibros/backend/EntreLibrosBackendApplication.java
+++ b/src/main/java/com/entrelibros/backend/EntreLibrosBackendApplication.java
@@ -1,0 +1,12 @@
+package com.entrelibros.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EntreLibrosBackendApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EntreLibrosBackendApplication.class, args);
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/AuthController.java
+++ b/src/main/java/com/entrelibros/backend/auth/AuthController.java
@@ -28,7 +28,8 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Validated @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
-        String cookiePath = contextPath.endsWith("/") ? contextPath + "auth" : contextPath + "/auth";
+        String normalizedContextPath = (contextPath == null || contextPath.isEmpty() || contextPath.equals("/")) ? "" : contextPath.replaceAll("/+$", "");
+        String cookiePath = normalizedContextPath + "/auth";
         ResponseCookie cookie = ResponseCookie.from("sessionToken", response.getToken())
             .httpOnly(true)
             .secure(true)

--- a/src/main/java/com/entrelibros/backend/auth/AuthController.java
+++ b/src/main/java/com/entrelibros/backend/auth/AuthController.java
@@ -3,6 +3,7 @@ package com.entrelibros.backend.auth;
 import com.entrelibros.backend.auth.dto.ApiResponse;
 import com.entrelibros.backend.auth.dto.LoginRequest;
 import com.entrelibros.backend.auth.dto.LoginResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -12,13 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
-
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/auth")
 public class AuthController {
 
     private final AuthService authService;
+    @Value("${server.servlet.context-path:}")
+    private String contextPath;
 
     public AuthController(AuthService authService) {
         this.authService = authService;
@@ -27,10 +28,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Validated @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
-        ResponseCookie cookie = ResponseCookie.from("sessionToken", UUID.randomUUID().toString())
+        String cookiePath = contextPath.endsWith("/") ? contextPath + "auth" : contextPath + "/auth";
+        ResponseCookie cookie = ResponseCookie.from("sessionToken", response.getToken())
             .httpOnly(true)
             .secure(true)
-            .path("/api/v1/auth")
+            .path(cookiePath)
             .sameSite("Strict")
             .build();
         return ResponseEntity.ok()

--- a/src/main/java/com/entrelibros/backend/auth/AuthController.java
+++ b/src/main/java/com/entrelibros/backend/auth/AuthController.java
@@ -1,0 +1,40 @@
+package com.entrelibros.backend.auth;
+
+import com.entrelibros.backend.auth.dto.ApiResponse;
+import com.entrelibros.backend.auth.dto.LoginRequest;
+import com.entrelibros.backend.auth.dto.LoginResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Validated @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        ResponseCookie cookie = ResponseCookie.from("sessionToken", UUID.randomUUID().toString())
+            .httpOnly(true)
+            .secure(true)
+            .path("/api/v1/auth")
+            .sameSite("Strict")
+            .build();
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .body(new ApiResponse<>(response));
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/AuthService.java
+++ b/src/main/java/com/entrelibros/backend/auth/AuthService.java
@@ -1,0 +1,40 @@
+package com.entrelibros.backend.auth;
+
+import com.entrelibros.backend.auth.dto.LoginRequest;
+import com.entrelibros.backend.auth.dto.LoginResponse;
+import com.entrelibros.backend.auth.dto.UserDto;
+import com.entrelibros.backend.security.JwtService;
+import com.entrelibros.backend.user.User;
+import com.entrelibros.backend.user.UserRepository;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    public AuthService(AuthenticationManager authenticationManager, UserRepository userRepository, JwtService jwtService) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.jwtService = jwtService;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        try {
+            authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        } catch (BadCredentialsException e) {
+            throw new InvalidCredentialsException();
+        }
+        User user = userRepository.findByEmail(request.getEmail())
+            .orElseThrow(InvalidCredentialsException::new);
+        String token = jwtService.generateToken(user);
+        UserDto userDto = new UserDto(user.getId(), user.getEmail(), user.getRole().name().toLowerCase());
+        return new LoginResponse(token, userDto, "auth.success.login");
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/InvalidCredentialsException.java
+++ b/src/main/java/com/entrelibros/backend/auth/InvalidCredentialsException.java
@@ -1,0 +1,4 @@
+package com.entrelibros.backend.auth;
+
+public class InvalidCredentialsException extends RuntimeException {
+}

--- a/src/main/java/com/entrelibros/backend/auth/RestExceptionHandler.java
+++ b/src/main/java/com/entrelibros/backend/auth/RestExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.entrelibros.backend.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidCredentials(InvalidCredentialsException ex) {
+        ProblemDetail detail = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        detail.setTitle("Unauthorized");
+        detail.setProperty("code", "InvalidCredentials");
+        detail.setProperty("messageKey", "auth.errors.invalid_credentials");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(detail);
+        }
+}

--- a/src/main/java/com/entrelibros/backend/auth/RestExceptionHandler.java
+++ b/src/main/java/com/entrelibros/backend/auth/RestExceptionHandler.java
@@ -16,5 +16,5 @@ public class RestExceptionHandler {
         detail.setProperty("code", "InvalidCredentials");
         detail.setProperty("messageKey", "auth.errors.invalid_credentials");
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(detail);
-        }
+    }
 }

--- a/src/main/java/com/entrelibros/backend/auth/dto/ApiResponse.java
+++ b/src/main/java/com/entrelibros/backend/auth/dto/ApiResponse.java
@@ -1,0 +1,13 @@
+package com.entrelibros.backend.auth.dto;
+
+public class ApiResponse<T> {
+    private T data;
+
+    public ApiResponse(T data) {
+        this.data = data;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/dto/LoginRequest.java
+++ b/src/main/java/com/entrelibros/backend/auth/dto/LoginRequest.java
@@ -1,0 +1,30 @@
+package com.entrelibros.backend.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/dto/LoginResponse.java
+++ b/src/main/java/com/entrelibros/backend/auth/dto/LoginResponse.java
@@ -1,0 +1,25 @@
+package com.entrelibros.backend.auth.dto;
+
+public class LoginResponse {
+    private String token;
+    private UserDto user;
+    private String messageKey;
+
+    public LoginResponse(String token, UserDto user, String messageKey) {
+        this.token = token;
+        this.user = user;
+        this.messageKey = messageKey;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public UserDto getUser() {
+        return user;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
+    }
+}

--- a/src/main/java/com/entrelibros/backend/auth/dto/UserDto.java
+++ b/src/main/java/com/entrelibros/backend/auth/dto/UserDto.java
@@ -1,0 +1,27 @@
+package com.entrelibros.backend.auth.dto;
+
+import java.util.UUID;
+
+public class UserDto {
+    private UUID id;
+    private String email;
+    private String role;
+
+    public UserDto(UUID id, String email, String role) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/entrelibros/backend/security/JwtService.java
+++ b/src/main/java/com/entrelibros/backend/security/JwtService.java
@@ -22,7 +22,11 @@ public class JwtService {
     public JwtService(@Value("${jwt.secret}") String secret,
                       @Value("${jwt.accessTtl}") Duration accessTtl,
                       @Value("${jwt.issuer}") String issuer) {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        byte[] secretBytes = secret.getBytes(StandardCharsets.UTF_8);
+        if (secretBytes.length < 32) {
+            throw new IllegalArgumentException("JWT secret key must be at least 32 bytes (256 bits) for HMAC-SHA256.");
+        }
+        this.key = Keys.hmacShaKeyFor(secretBytes);
         this.accessTtl = accessTtl;
         this.issuer = issuer;
     }

--- a/src/main/java/com/entrelibros/backend/security/JwtService.java
+++ b/src/main/java/com/entrelibros/backend/security/JwtService.java
@@ -1,0 +1,43 @@
+package com.entrelibros.backend.security;
+
+import com.entrelibros.backend.user.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+public class JwtService {
+
+    private final SecretKey key;
+    private final Duration accessTtl;
+    private final String issuer;
+
+    public JwtService(@Value("${jwt.secret}") String secret,
+                      @Value("${jwt.accessTtl}") Duration accessTtl,
+                      @Value("${jwt.issuer}") String issuer) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTtl = accessTtl;
+        this.issuer = issuer;
+    }
+
+    public String generateToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTtl.toMillis());
+        return Jwts.builder()
+            .setSubject(user.getId().toString())
+            .setIssuer(issuer)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .claim("email", user.getEmail())
+            .claim("role", user.getRole().name().toLowerCase())
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+}

--- a/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
+++ b/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/login").permitAll()
+                .requestMatchers("/api/v1/auth/**").permitAll()
                 .anyRequest().authenticated());
         return http.build();
     }

--- a/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
+++ b/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/auth/login").permitAll()
+                .requestMatchers("/auth/login").permitAll()
                 .anyRequest().authenticated());
         return http.build();
     }

--- a/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
+++ b/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/auth/**").permitAll()
+                .requestMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated());
         return http.build();
     }

--- a/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
+++ b/src/main/java/com/entrelibros/backend/security/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.entrelibros.backend.security;
+
+import com.entrelibros.backend.user.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/auth/login").permitAll()
+                .anyRequest().authenticated());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserRepository repository) {
+        return email -> repository.findByEmail(email)
+            .map(user -> (UserDetails) new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+            ))
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService, PasswordEncoder encoder) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(encoder);
+        return new ProviderManager(provider);
+    }
+}

--- a/src/main/java/com/entrelibros/backend/user/User.java
+++ b/src/main/java/com/entrelibros/backend/user/User.java
@@ -1,0 +1,62 @@
+package com.entrelibros.backend.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    public enum Role { USER, ADMIN }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/entrelibros/backend/user/UserRepository.java
+++ b/src/main/java/com/entrelibros/backend/user/UserRepository.java
@@ -1,0 +1,10 @@
+package com.entrelibros.backend.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 4000
+  servlet:
+    context-path: /api/v1
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/entrelibros
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+  flyway:
+    enabled: true
+
+jwt:
+  secret: "01234567890123456789012345678901"
+  issuer: "https://entrelibros.app"
+  accessTtl: PT15M

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,6 @@ spring:
     enabled: true
 
 jwt:
-  secret: "01234567890123456789012345678901"
+  secret: ${JWT_SECRET}
   issuer: "https://entrelibros.app"
   accessTtl: PT15M

--- a/src/main/resources/db/migration/V1__create_users.sql
+++ b/src/main/resources/db/migration/V1__create_users.sql
@@ -1,0 +1,6 @@
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(20) NOT NULL
+);

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -14,6 +14,9 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.UUID;
 
@@ -22,16 +25,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Testcontainers
 class AuthControllerTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
     @DynamicPropertySource
     static void overrideProps(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
-        registry.add("spring.datasource.username", () -> "sa");
-        registry.add("spring.datasource.password", () -> "");
-        registry.add("spring.datasource.driverClassName", () -> "org.h2.Driver");
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-        registry.add("spring.flyway.enabled", () -> "false");
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driverClassName", postgres::getDriverClassName);
         registry.add("JWT_SECRET", () -> "test-secret-0123456789abcdef0123456789abcd");
     }
 

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -13,9 +13,6 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
@@ -25,17 +22,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Testcontainers
 class AuthControllerTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
     @DynamicPropertySource
     static void overrideProps(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("spring.datasource.driverClassName", () -> "org.h2.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> "false");
         registry.add("JWT_SECRET", () -> "test-secret-0123456789abcdef0123456789abcd");
     }
 

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -67,7 +67,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest();
         request.setEmail("user@entrelibros.com");
         request.setPassword("correcthorsebatterystaple");
-        mockMvc.perform(post("/auth/login").contextPath("/api/v1")
+        mockMvc.perform(post("/api/v1/auth/login").contextPath("/api/v1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
@@ -82,7 +82,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest();
         request.setEmail("user@entrelibros.com");
         request.setPassword("wrong");
-        mockMvc.perform(post("/auth/login").contextPath("/api/v1")
+        mockMvc.perform(post("/api/v1/auth/login").contextPath("/api/v1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isUnauthorized())

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -36,6 +36,7 @@ class AuthControllerTest {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("JWT_SECRET", () -> "test-secret");
     }
 
     @Autowired

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -67,7 +67,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest();
         request.setEmail("user@entrelibros.com");
         request.setPassword("correcthorsebatterystaple");
-        mockMvc.perform(post("/api/v1/auth/login")
+        mockMvc.perform(post("/auth/login").contextPath("/api/v1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
@@ -82,7 +82,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest();
         request.setEmail("user@entrelibros.com");
         request.setPassword("wrong");
-        mockMvc.perform(post("/api/v1/auth/login")
+        mockMvc.perform(post("/auth/login").contextPath("/api/v1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isUnauthorized())

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -1,0 +1,91 @@
+package com.entrelibros.backend.auth;
+
+import com.entrelibros.backend.auth.dto.LoginRequest;
+import com.entrelibros.backend.user.User;
+import com.entrelibros.backend.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthControllerTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setEmail("user@entrelibros.com");
+        user.setPassword(passwordEncoder.encode("correcthorsebatterystaple"));
+        user.setRole(User.Role.USER);
+        userRepository.save(user);
+    }
+
+    @Test
+    void loginSuccess() throws Exception {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("user@entrelibros.com");
+        request.setPassword("correcthorsebatterystaple");
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(header().stringValues("Set-Cookie", org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("sessionToken"))))
+            .andExpect(jsonPath("$.data.token").isNotEmpty())
+            .andExpect(jsonPath("$.data.user.email").value("user@entrelibros.com"))
+            .andExpect(jsonPath("$.data.messageKey").value("auth.success.login"));
+    }
+
+    @Test
+    void loginInvalidPassword() throws Exception {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("user@entrelibros.com");
+        request.setPassword("wrong");
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("InvalidCredentials"))
+            .andExpect(jsonPath("$.messageKey").value("auth.errors.invalid_credentials"));
+    }
+}

--- a/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/entrelibros/backend/auth/AuthControllerTest.java
@@ -36,7 +36,7 @@ class AuthControllerTest {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("JWT_SECRET", () -> "test-secret");
+        registry.add("JWT_SECRET", () -> "test-secret-0123456789abcdef0123456789abcd");
     }
 
     @Autowired


### PR DESCRIPTION
## Summary
- set up Spring Boot 3 project with Maven
- implement `/api/v1/auth/login` endpoint issuing JWT and refresh cookie
- add Postgres schema migration and security config using Argon2
- cover login with integration tests (Testcontainers)
- run Maven build in CI for pull requests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.5 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68a8bdca5be0832ebc8f6c9cc8f68a07