### PR TITLE
Add script for running tests without Docker

### DIFF
--- a/run-tests-no-docker.sh
+++ b/run-tests-no-docker.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Override Testcontainers-based datasource with local Postgres
+export SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver
+export SPRING_DATASOURCE_URL="${SPRING_DATASOURCE_URL:-jdbc:postgresql://localhost:5432/entrelibros}"
+export SPRING_DATASOURCE_USERNAME="${SPRING_DATASOURCE_USERNAME:-postgres}"
+export SPRING_DATASOURCE_PASSWORD="${SPRING_DATASOURCE_PASSWORD:-postgres}"
+
+mvn -Djava.net.preferIPv4Stack=true -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 test


### PR DESCRIPTION
## Summary
- add helper script to run Maven tests against a local Postgres instance instead of using Testcontainers

## Testing
- `./run-tests-no-docker.sh` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cb0db9c832e9658db33c270d41d